### PR TITLE
README: Fix a couple of typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The `@rename` tag renames the class to `Foo::Baz`.
 
 ```rust
 /// @yard
-/// @remame Foo::Baz
+/// @rename Foo::Baz
 pub struct InnerName { }
 ```
 
@@ -109,7 +109,7 @@ impl Bar {
 
 #### Tips
 
-YARD's syntax differs from what Rustdoc expects. Linters you man want to disable:
+YARD's syntax differs from what Rustdoc expects. Linters you might want to disable:
 
 ```rust
 #![allow(rustdoc::broken_intra_doc_links)]


### PR DESCRIPTION
Just fixing a couple of typos in the README from an initial read of it.

Additionally, the following example also looks off

> Defines `Foo::Bar.new` -- class method because the first argument isn't `self`.
> ```rust
> impl Bar {
>     /// @yard
>     /// @return [Foo::Bar]
>     fn build() -> Self {}
> }
> ```

Should that say that it defines `Foo::Bar.build` or the rust function be renamed to `fn new`? 